### PR TITLE
Fix memory leak in wocky_xmpp_reader

### DIFF
--- a/rpm/telepathy-gabble.spec
+++ b/rpm/telepathy-gabble.spec
@@ -12,8 +12,9 @@ Source2:    mktests.sh
 Patch0:     nemo-tests-dir-fix.patch
 Patch1:     0001-Disable-parallel-build-for-extensions-directory.patch
 Patch2:	    wocky-disable-gtkdoc.patch
-Patch3:     0001-Change-default-keepalive-interval-to-2.5-minutes.patch
-Patch4:     0001-switch-to-using-gireactor-to-work-with-new-gi-based-.patch
+Patch3:     wocky-mem-leak.patch
+Patch4:     0001-Change-default-keepalive-interval-to-2.5-minutes.patch
+Patch5:     0001-switch-to-using-gireactor-to-work-with-new-gi-based-.patch
 Requires:   telepathy-mission-control
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
@@ -66,11 +67,12 @@ tests.xml for automated testing.
 %patch1 -p1
 cd lib/ext/wocky
 %patch2 -p1
+%patch3 -p1
 cd ../../..
 # 0001-Change-default-keepalive-interval-to-2.5-minutes.patch
-%patch3 -p1
-# 0001-switch-to-using-gireactor-to-work-with-new-gi-based-.patch
 %patch4 -p1
+# 0001-switch-to-using-gireactor-to-work-with-new-gi-based-.patch
+%patch5 -p1
 
 # >> setup
 %__cp $RPM_SOURCE_DIR/mktests.sh tests/

--- a/rpm/wocky-mem-leak.patch
+++ b/rpm/wocky-mem-leak.patch
@@ -1,0 +1,12 @@
+diff --git a/wocky/wocky-xmpp-reader.c b/wocky/wocky-xmpp-reader.c
+index f0eaa92..721e93d 100644
+--- a/wocky/wocky-xmpp-reader.c
++++ b/wocky/wocky-xmpp-reader.c
+@@ -328,6 +328,7 @@ wocky_xmpp_reader_finalize (GObject *object)
+   /* free any data held directly by the object here */
+   g_queue_free (priv->stanzas);
+   g_queue_free (priv->nodes);
++  g_free (priv->default_namespace);
+ 
+   if (priv->error != NULL)
+     g_error_free (priv->error);


### PR DESCRIPTION
```
==17443== 67 bytes in 67 blocks are definitely lost in loss record 2,625 of 3,184
==17443==    at 0x483F380: malloc (vg_replace_malloc.c:296)
==17443==    by 0x4F49083: g_malloc (gmem.c:104)
==17443==    by 0x4F60AA9: g_strdup (gstrfuncs.c:364)
==17443==    by 0x48AD41D: wocky_xmpp_reader_set_property (wocky-xmpp-reader.c:354)
==17443==    by 0x4EB27C3: object_set_property (gobject.c:1366)
==17443==    by 0x4EB27C3: g_object_new_internal (gobject.c:1779)
==17443==    by 0x4EB27C3: g_object_newv (gobject.c:1890)
==17443==    by 0x4EB321F: g_object_new (gobject.c:1556)
==17443==    by 0x48AB959: wocky_xmpp_connection_init (wocky-xmpp-connection.c:126)
==17443==    by 0x4ECB115: g_type_create_instance (gtype.c:1868)
==17443==    by 0x4EB02C3: g_object_new_internal (gobject.c:1746)
==17443==    by 0x4EB2BB7: g_object_new_valist (gobject.c:2002)
==17443==    by 0x4EB320B: g_object_new (gobject.c:1559)
==17443==    by 0x4889FED: maybe_old_ssl (wocky-connector.c:1076)
==17443==    by 0x488A183: tcp_host_connected (wocky-connector.c:990)
==17443==    by 0x4DE82A7: g_task_return_now (gtask.c:1108)
==17443==    by 0x4DE82A7: g_task_return (gtask.c:1161)
==17443==    by 0x4DE82A7: g_task_return_pointer (gtask.c:1486)
==17443==    by 0x4DE31D5: g_socket_client_async_connect_complete (gsocketclient.c:1409)
==17443==    by 0x4DE33DF: g_socket_client_connected_callback (gsocketclient.c:1599)
==17443==    by 0x4DE84C9: g_task_return_now (gtask.c:1108)
==17443==    by 0x4DE84C9: g_task_return (gtask.c:1161)
==17443==    by 0x4DE84C9: g_task_return_boolean (gtask.c:1592)
==17443==    by 0x4DE4697: g_socket_connection_connect_callback (gsocketconnection.c:231)
==17443==    by 0x4DDD75F: socket_source_dispatch (gsocket.c:3264)
==17443==    by 0x4F43B85: g_main_dispatch (gmain.c:3066)
==17443==    by 0x4F43B85: g_main_context_dispatch (gmain.c:3642)
==17443==    by 0x4F43E11: g_main_context_iterate.isra.5 (gmain.c:3713)
==17443==    by 0x4F441D3: g_main_loop_run (gmain.c:3907)
==17443==    by 0x4BD1437: tp_run_connection_manager (run.c:285)
==17443==    by 0x2F9A9: gabble_main (gabble.c:177)
==17443==    by 0x5042939: (below main) (libc-start.c:287)
```
